### PR TITLE
Make it rain

### DIFF
--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -19,8 +19,9 @@ build_targets:
       - apt-get install -yq rsync
       - git config --global user.name "Garden CI"
       - git config --global user.email "admin@garden.io"
-      - cd garden-service
       - npm install
+      - cd garden-service
+      - npm run build
       - npm test
 
 ci:

--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -440,8 +440,9 @@
       }
     },
     "@kubernetes/client-node": {
-      "version": "git+https://github.com/garden-io/javascript.git#8051f4d1bbfcf5c8cc867ea03510f766aa526771",
-      "from": "git+https://github.com/garden-io/javascript.git#client-cert-auth",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.10.2.tgz",
+      "integrity": "sha512-JvsmxbTwiMqsh9LyuXMzT5HjoENFbB3a/JroJsobuAzkxN162UqAOvg++/AA+ccIMWRR2Qln4FyaOJ0a4eKyXg==",
       "requires": {
         "@types/js-yaml": "^3.12.1",
         "@types/node": "^10.12.0",
@@ -460,9 +461,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.16",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.16.tgz",
-          "integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA=="
+          "version": "10.14.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.17.tgz",
+          "integrity": "sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ=="
         }
       }
     },

--- a/garden-service/package.json
+++ b/garden-service/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@hapi/joi": "^15.1.1",
-    "@kubernetes/client-node": "git+https://github.com/garden-io/javascript.git#client-cert-auth",
+    "@kubernetes/client-node": "0.10.2",
     "JSONStream": "^1.3.5",
     "analytics-node": "3.3.0",
     "ansi-escapes": "^4.2.1",


### PR DESCRIPTION
This seems to fix it - not sure about the git-pinned kubernetes client (it can't seem to find it and also complains about a typescript syntax error, which looks like a version mismatch between what's installed and being used) but using the core one at least gets past that for now. The missing magic was `npm run build` -- the CircleCI yaml specifies that `test-server` is dependent on `build` ... which does the `npm run build` magic 

